### PR TITLE
WIP: Buffer blobs and blocks before fork choice

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -52,8 +52,7 @@
 #![allow(clippy::result_large_err)]
 
 use crate::blob_verification::{
-    validate_blob_for_gossip, AsBlock, AvailableBlock, BlobError, BlockWrapper, IntoAvailableBlock,
-    IntoBlockWrapper,
+    AsBlock, AvailableBlock, BlobError, BlockWrapper, IntoAvailableBlock, IntoBlockWrapper,
 };
 use crate::eth1_finalization_cache::Eth1FinalizationData;
 use crate::execution_payload::{
@@ -929,7 +928,7 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
         // Validate the block's execution_payload (if any).
         validate_execution_payload_for_gossip(&parent_block, block.message(), chain)?;
 
-        let available_block = validate_blob_for_gossip(block, block_root, chain)?;
+        let available_block = block.into_available_block(block_root, chain)?;
 
         // Having checked the proposer index and the block root we can cache them.
         let consensus_context = ConsensusContext::new(available_block.slot())
@@ -947,6 +946,11 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
 
     pub fn block_root(&self) -> Hash256 {
         self.block_root
+    }
+
+    pub fn set_block(mut self, available_block: AvailableBlock<T::EthSpec>) -> Self {
+        self.block = available_block;
+        self
     }
 }
 

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1,4 +1,7 @@
-use crate::beacon_chain::{CanonicalHead, BEACON_CHAIN_DB_KEY, ETH1_CACHE_DB_KEY, OP_POOL_DB_KEY};
+use crate::beacon_chain::{
+    CanonicalHead, BEACON_CHAIN_DB_KEY, DEFAULT_BLOBS_BUFFER_SIZE, DEFAULT_BLOCK_BUFFER_SIZE,
+    ETH1_CACHE_DB_KEY, OP_POOL_DB_KEY,
+};
 use crate::blob_cache::BlobCache;
 use crate::eth1_chain::{CachingEth1Backend, SszEth1};
 use crate::eth1_finalization_cache::Eth1FinalizationCache;
@@ -22,6 +25,7 @@ use execution_layer::ExecutionLayer;
 use fork_choice::{ForkChoice, ResetPayloadStatuses};
 use futures::channel::mpsc::Sender;
 use kzg::{Kzg, TrustedSetup};
+use lru::LruCache;
 use operation_pool::{OperationPool, PersistedOperationPool};
 use parking_lot::RwLock;
 use proto_array::ReOrgThreshold;
@@ -852,6 +856,8 @@ where
             validator_monitor: RwLock::new(validator_monitor),
             blob_cache: BlobCache::default(),
             kzg,
+            block_buffer: LruCache::new(DEFAULT_BLOCK_BUFFER_SIZE),
+            blobs_buffer: LruCache::new(DEFAULT_BLOBS_BUFFER_SIZE),
         };
 
         let head = beacon_chain.head_snapshot();

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -1779,15 +1779,17 @@ impl<T: BeaconChainTypes> BeaconProcessor<T> {
                 blob_sidecar,
                 subnet,
                 seen_timestamp,
-            } => task_spawner.spawn_blocking(move || {
-                worker.process_gossip_blob_sidecar(
-                    message_id,
-                    peer_id,
-                    blob_sidecar,
-                    subnet,
-                    Some(work_reprocessing_tx),
-                    seen_timestamp,
-                )
+            } => task_spawner.spawn_async(async move {
+                worker
+                    .process_gossip_blob_sidecar(
+                        message_id,
+                        peer_id,
+                        blob_sidecar,
+                        subnet,
+                        Some(work_reprocessing_tx),
+                        seen_timestamp,
+                    )
+                    .await
             }),
             Work::UnknownBlobSidecar {
                 message_id,
@@ -1795,15 +1797,17 @@ impl<T: BeaconChainTypes> BeaconProcessor<T> {
                 blob_sidecar,
                 subnet,
                 seen_timestamp,
-            } => task_spawner.spawn_blocking(move || {
-                worker.process_gossip_blob_sidecar(
-                    message_id,
-                    peer_id,
-                    blob_sidecar,
-                    subnet,
-                    None,
-                    seen_timestamp,
-                )
+            } => task_spawner.spawn_async(async move {
+                worker
+                    .process_gossip_blob_sidecar(
+                        message_id,
+                        peer_id,
+                        blob_sidecar,
+                        subnet,
+                        None,
+                        seen_timestamp,
+                    )
+                    .await
             }),
 
             /*

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -697,12 +697,12 @@ impl<T: BeaconChainTypes> Worker<T> {
             return
         };
         let fork_choice_unverified_block = if is_dab_check && has_blobs {
-            let Some(blobs) = self.chain.blobs_buffer.pop(&block_root) else {
+            let Some(blobs) = self.chain.blobs_buffer.get(&block_root) else {
                 debug!(
                     self.log, "Still waiting on blobs that are kzg-commited in block";
                     "block_root" => %block_root,
                 );
-                self.chain.block_buffer.put(block_root, gossip_verified_block);
+                self.chain.block_buffer.put(block_root, BlockBufferItem::new(block_root, gossip_verified_block));
                 return
             };
             let block = gossip_verified_block.block.deconstruct().0;
@@ -763,7 +763,7 @@ impl<T: BeaconChainTypes> Worker<T> {
 
                 let block_root = validated_sidecar.beacon_block_root;
 
-                let Some(gossip_verified_block) = self.chain.block_buffer.pop(&block_root) else {
+                let Some(block) = self.chain.block_buffer.get(&block_root) else {
                     debug!(
                         self.log, "Still waiting on block that kzg-commits blobs";
                         "block_root" => %block_root,
@@ -772,7 +772,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     return
                 };
 
-                let block = gossip_verified_block.block.block_cloned();
+                let block = block..block_cloned();
                 // todo(emhane): What do we want to do if these blobs didn't match the block?
                 let Ok(wrapper) =  couple_block_and_blobs_for_import_to_fork_choice(
                     block,


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/3991

## Proposed Changes

Blocks and blobs will be stored in buffer for max an epoch, so next blob to come over network for a group, reads the rest of the group from buffers and creates a new `AvailabilityPendingBlock` and attempts to be imported into chain. This should somehow tie in with updating how `SyncMessage::UnknownBlock` is handled on `BlockError::ParentUnknown`, as we may not have to fetch the parent block itself but the parent's blobs to make the parent block available (so we can import it), and we will look in buffers to find out which components of the block-blobs group is missing.

## Additional Info
